### PR TITLE
Implemented IPs ban by range

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -96,7 +96,7 @@ class Plugin extends PluginBase
     {
         $ip = Request::ip();
         try {
-            $match = \Filipac\Banip\Models\Ip::where('address','=',$ip)->get();
+            $match = $this->getMatchedBanIp($ip);
         } catch (QueryException $e) {
             \Log::info('The Filipac.Banip was not properly installed (missing table)');
             return;
@@ -133,5 +133,16 @@ class Plugin extends PluginBase
         return (php_sapi_name() === 'cli');
     }
 
+    private function getMatchedBanIp($ip)
+    {
+        // Numeric form of ip
+        $numericIp = ip2long($ip);
+        // Convert to unsigned integer representation
+        $u32StrIp = sprintf("%u", $numericIp);
 
+        $match = \Filipac\Banip\Models\Ip::where('lower_ip_range', '<=', $u32StrIp)
+            ->where('upper_ip_range', '>=', $u32StrIp)
+            ->get();
+        return $match;
+    }
 }

--- a/controllers/Ips.php
+++ b/controllers/Ips.php
@@ -60,10 +60,19 @@ class Ips extends Controller
         $this->listConfig = 'config_list.yaml';
         $this->makeLists();
         $v = Validator::make(Input::all(), [
-         'Ip.address' => 'required|ip'
+         'Ip.address' => 'required|ip|unique:filipac_banip_ips,address',
+         'Ip.address_end' => 'ip',
+         'Ip.mask' => 'integer|min:1|max:32',
         ], [
             'Ip.address.required' => 'Please enter an valid IP Address to ban',
-            'Ip.address.ip' => 'Please enter an valid IP Address to ban'
+            'Ip.address.ip' => 'Please enter an valid IP Address to ban',
+            'Ip.address.unique' => 'Please enter an unique IP Address to ban',
+            'Ip.address_end.required' => 'Please enter an valid IP Address to ban',
+            'Ip.address_end.ip' => 'Please enter an valid IP Address to ban',
+            'Ip.address_end.unique' => 'Please enter an unique IP Address to ban',
+            'Ip.mask.integer' => 'Please enter an integer value between 1 and 32',
+            'Ip.mask.min' => 'Please enter an integer value between 1 and 32',
+            'Ip.mask.max' => 'Please enter an integer value between 1 and 32',
         ]);
         if($v->fails()) {
             Flash::error(implode('<br>',$v->messages()->all()));
@@ -71,6 +80,8 @@ class Ips extends Controller
         }
         $ip = new Ip;
         $ip->address = Input::all()['Ip']['address'];
+        $ip->address_end= Input::all()['Ip']['address_end'];
+        $ip->mask = Input::all()['Ip']['mask'];
         $ip->save();
         Flash::success('The IP was banned.');
         return ['success'=>true] + $this->listRefresh('Lists');

--- a/models/Ip.php
+++ b/models/Ip.php
@@ -36,4 +36,54 @@ class Ip extends Model
     public $attachOne = [];
     public $attachMany = [];
 
+    public function beforeSave()
+    {
+        $this->correctFields($this);
+    }
+
+    public static function correctFields($item) {
+        // Current values
+        $addressStart = $item->address;
+        $addressEnd = $item->address_end;
+        $mask = $item->mask;
+
+        // Check what values are defined
+        $addressStartIsDefined = filter_var($addressStart, FILTER_VALIDATE_IP) !== false;
+        $addressEndIsDefined = filter_var($addressEnd, FILTER_VALIDATE_IP) !== false;
+        $maskIsDefined = ($mask >= 1) && ($mask <= 32);
+
+        if ($addressStartIsDefined == true) {
+            // Numeric representation of start ip address
+            $numStart = ip2long($addressStart);
+            // Store in unsigned integer representation
+            $item->lower_ip_range = sprintf("%u", $numStart);
+
+            if ($addressEndIsDefined == true) {
+                // Numeric representation of start ip address
+                $numEnd = ip2long($addressEnd);
+                // Store in unsigned integer representation
+                $item->upper_ip_range = sprintf("%u", $numEnd);
+                // Mask unused
+                $item->mask = 0;
+            } else if ($maskIsDefined == true) {
+                // Mask for lsb
+                $maskValueOr = 0xffffffff >> $mask;
+                // Calculate end ip address
+                $numEnd = $numStart | $maskValueOr;
+                // Store in unsigned integer representation
+                $item->upper_ip_range = sprintf("%u", $numEnd);
+                // Address end unused
+                $item->address_end = '';
+            } else {
+                // By default start = end
+                $numEnd = $numStart;
+                // Store in unsigned integer representation
+                $item->upper_ip_range = sprintf("%u", $numEnd);
+                // Store in dotted string representation
+                $item->address_end = long2ip($numEnd);
+                // Default mask /32
+                $item->mask = 32;
+            }
+        }
+    }
 }

--- a/models/ip/columns.yaml
+++ b/models/ip/columns.yaml
@@ -4,5 +4,11 @@
 
 columns:
     address:
-        label: Address
+        label: Address start
+        searchable: true
+    address_end:
+        label: Address end
+        searchable: true
+    mask:
+        label: Mask
         searchable: true

--- a/models/ip/fields.yaml
+++ b/models/ip/fields.yaml
@@ -4,8 +4,18 @@
 
 fields:
     address:
-            label: Address
-            span: full
-            required: true
-            attributes:
-                default-focus: 1
+        label: Address first
+        span: left
+        required: true
+        attributes:
+            default-focus: 1
+    address_end:
+        label: Address last
+        span: right
+        required: false
+        default: ''
+    mask:
+        label: Mask
+        span: left
+        required: false
+        default: 32

--- a/updates/ips_table_add_columns_ip_range.php
+++ b/updates/ips_table_add_columns_ip_range.php
@@ -1,0 +1,32 @@
+<?php namespace Filipac\Banip\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class IpsTableAddColumnMask  extends Migration
+{
+
+    public function up()
+    {
+        Schema::table('filipac_banip_ips', function ($table) {
+            // Add column `upper ip range`
+            $table->bigInteger('upper_ip_range')->after('address')->default(0)->unsigned();
+            // Add column `lower ip range`
+            $table->bigInteger('lower_ip_range')->after('address')->default(0)->unsigned();
+            // Add column `mask`
+            $table->integer('mask')->after('address')->default(32);
+            // Add column `mask`
+            $table->string('address_end')->after('address');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('filipac_banip_ips', function ($table) {
+            $table->dropColumn('address_end');
+            $table->dropColumn('mask');
+            $table->dropColumn('lower_ip_range');
+            $table->dropColumn('upper_ip_range');
+        });
+    }
+}

--- a/updates/ips_table_add_columns_ip_range.php
+++ b/updates/ips_table_add_columns_ip_range.php
@@ -1,7 +1,9 @@
 <?php namespace Filipac\Banip\Updates;
 
+use DB;
 use Schema;
 use October\Rain\Database\Updates\Migration;
+use filipac\Banip\Models\Ip as IpModel;
 
 class IpsTableAddColumnMask  extends Migration
 {
@@ -17,6 +19,13 @@ class IpsTableAddColumnMask  extends Migration
             $table->integer('mask')->after('address')->default(32);
             // Add column `mask`
             $table->string('address_end')->after('address');
+        });
+
+        IpModel::chunk(100, function ($items) {
+            foreach ($items as $item) {
+                IpModel::correctFields($item);
+                $item->save();
+            }
         });
     }
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,6 +1,10 @@
-1.0.1:
+﻿1.0.1:
   - First version of Banip
   - create_ips_table.php
 1.0.2: Use Illuminate component to get the IP to prevent spoofing
 1.0.3: Fix version to allow updates (in Plugin.php)
 1.0.4: Respect when there is no layout selected
+1.0.5:
+  - Ban IPs by range
+  - Add fields for ip range to table 'filipac_banip_ips'
+  - ips_table_add_columns_ip_range.php


### PR DESCRIPTION
This modification allows ban IPs by specified range.

Range can be set with mask or with second IP:
 * If mask and second IP not specified, then used mask set to 32 and second IP set equals to first IP.
 * If second IP specified, but mask not, then mask set to zero (unused).
 * If mask specified, but second IP not, then second IP set to empty string (unused).

Before saving 'Ip' model to DB, its IP addresses in numeric representation are calculated and added to fields.
On plugin's boot, client's IP converts to numeric representation and checked in DB.